### PR TITLE
Update publishAndStartService.template.sh to use correct command syntax

### DIFF
--- a/tutorials/howToWritePythonService/template/publishAndStartService.template.sh
+++ b/tutorials/howToWritePythonService/template/publishAndStartService.template.sh
@@ -10,9 +10,9 @@ echo "Publishing your service. Please wait..."
 
 TMP_FILE=/tmp/__SNET_SERVICE_PUBLISH_LOG.txt
 rm -f $TMP_FILE
-snet service metadata_init __PROTO_DIR__ __SERVICE_NAME__ $1
-snet service metadata_set_fixed_price 0.00000001
-snet service metadata_add_endpoints http://localhost:7000
+snet service metadata-init __PROTO_DIR__ __SERVICE_NAME__ $1
+snet service metadata-set-fixed-price 0.00000001
+snet service metadata-add-endpoints http://localhost:7000
 snet service publish __ORGANIZATION_NAME__ __SERVICE_NAME__ -y 2>&1 | tee $TMP_FILE
 python3 server.py &
 snetd --config __DAEMON_CONFIG_FILE__ &


### PR DESCRIPTION
fixed the snet cli metadata commands to use - instead of _ to correctly match the cli interface