### PR TITLE
Add deprecation banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# This repo is deprecated, please use https://github.com/singnet/dev-portal instead
+
 # SingularityNET Documentation Wiki
 
 > SingularityNET is still under active development. The design is


### PR DESCRIPTION
Add deprecation banner as wiki repo is deprecated and replaced by https://github.com/singnet/dev-portal